### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/laurentgosselin0451/d0496dfb-2d6b-43b7-b76a-eeda6418d001/90e0f6ee-7f74-49e3-ac57-f9f0244818f8/_apis/work/boardbadge/d890aab2-3fc9-415c-96ac-4a7778f4677d)](https://dev.azure.com/laurentgosselin0451/d0496dfb-2d6b-43b7-b76a-eeda6418d001/_boards/board/t/90e0f6ee-7f74-49e3-ac57-f9f0244818f8/Microsoft.RequirementCategory)
 
 [![Build Status](https://dev.azure.com/laurentgosselin0451/test_js_pipeline/_apis/build/status%2Flg37.js-e2e-express-server?branchName=main)](https://dev.azure.com/laurentgosselin0451/test_js_pipeline/_build/latest?definitionId=4&branchName=main)
 ---


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/laurentgosselin0451/d0496dfb-2d6b-43b7-b76a-eeda6418d001/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.